### PR TITLE
Observation groups and CareTeam Updates

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,17 @@
+
+## Release 1.0.18-RELEASE
+- Support /observationssegmented query by value set for a segemented valueset retrieval - Added initial mappers for PractitionerRole
+- Add ObservationCollection and ObservationList to support /observationssegmented query
+- Added property mcc.provider.pullbyrole
+- Added properties to control contact fetch (mcc.careteam.use.active, mcc.careteam.use.careplan)
+- Updated contact mapping to make a best attempt to get Telephone, Email and Address, includes scanning Provider Role and Enhanced organization use.
+- Added new Query Key: PractitionerRole.Query=/PractitionerRole/?practitioner={id}&active=true
+- Added new Query Key: CareTeam.Query.ActiveList=/CareTeam/?subject={subject}&status=active
+- Updated ParctitionerRole query to use internal overridable system.
+- Enhanced CareTeam mapping to do a first cut on ParctitionerRole.
+- Enhanced CareTeam mapping to log unknown member types.
+
+
 ## Release 1.0.17-RELEASE
 - Refactored all mapping to use beans
 - Removed PATIENT_ID_CHECK code

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -11,7 +11,6 @@
 - Enhanced CareTeam mapping to do a first cut on ParctitionerRole.
 - Enhanced CareTeam mapping to log unknown member types.
 
-
 ## Release 1.0.17-RELEASE
 - Refactored all mapping to use beans
 - Removed PATIENT_ID_CHECK code

--- a/README.MD
+++ b/README.MD
@@ -94,8 +94,8 @@ details on Spring boot.
 | fhir.secure.server.address | FHIR_SECURE_SERVER_ADDRESS |Default secure fhir server | https://api.logicahealth.org/MCCeCarePlanTest/data | https://api.logicahealth.org/MCCeCarePlanTest/data |
 | logging.level.org.springframework | | | WARN | WARN |
 | mcc.patient.id.system | MCC_PATIENT_ID_SYSTEM | System used to determine the Patient Id| | | |
-| mcc.provider.pullbyrole | MCC_PROVIDER_PULLBYROLE | Allow provider contact info to be fecthed by practitioner role | TRUE | TRUE |
-| mcc.careteam.use.active | MCC_CARETEAM_USE_ACTIVE | Enable Contacts to look for careteams in none are a part of the selected careplan | TRUE | TRUE |
+| mcc.provider.pullbyrole | MCC_PROVIDER_PULLBYROLE | Allow provider contact info to be fetched by practitioner role | TRUE | TRUE |
+| mcc.careteam.use.active | MCC_CARETEAM_USE_ACTIVE | Enable Contacts to look for careteams if none are a part of the selected careplan | TRUE | TRUE |
 | mcc.careteam.use.careplan | MCC_CARETEAM_USE_CAREPLAN | Enable Contacts to us the currently selected Care plan to determine teams | TRUE | TRUE |
 
 

--- a/README.MD
+++ b/README.MD
@@ -94,6 +94,11 @@ details on Spring boot.
 | fhir.secure.server.address | FHIR_SECURE_SERVER_ADDRESS |Default secure fhir server | https://api.logicahealth.org/MCCeCarePlanTest/data | https://api.logicahealth.org/MCCeCarePlanTest/data |
 | logging.level.org.springframework | | | WARN | WARN |
 | mcc.patient.id.system | MCC_PATIENT_ID_SYSTEM | System used to determine the Patient Id| | | |
+| mcc.provider.pullbyrole | MCC_PROVIDER_PULLBYROLE | Allow provider contact info to be fecthed by practitioner role | TRUE | TRUE |
+| mcc.careteam.use.active | MCC_CARETEAM_USE_ACTIVE | Enable Contacts to look for careteams in none are a part of the selected careplan | TRUE | TRUE |
+| mcc.careteam.use.careplan | MCC_CARETEAM_USE_CAREPLAN | Enable Contacts to us the currently selected Care plan to determine teams | TRUE | TRUE |
+
+
 
 #### Configuring the patient identifier
 
@@ -194,6 +199,19 @@ The latest docker images are found on docker hub at https://hub.docker.com/repos
 
 #Recent Changes log
 
+## Release 1.0.18-RELEASE
+- Support /observationssegmented query by value set for a segemented valueset retrieval - Added initial mappers for PractitionerRole
+- Add ObservationCollection and ObservationList to support /observationssegmented query
+- Added property mcc.provider.pullbyrole
+- Added properties to control contact fetch (mcc.careteam.use.active, mcc.careteam.use.careplan)
+- Updated contact mapping to make a best attempt to get Telephone, Email and Address, includes scanning Provider Role and Enhanced organization use.
+- Added new Query Key: PractitionerRole.Query=/PractitionerRole/?practitioner={id}&active=true
+- Added new Query Key: CareTeam.Query.ActiveList=/CareTeam/?subject={subject}&status=active
+- Updated ParctitionerRole query to use internal overridable system.
+- Enhanced CareTeam mapping to do a first cut on ParctitionerRole.
+- Enhanced CareTeam mapping to log unknown member types.
+
+
 ## Release 1.0.17-RELEASE 
 - Refactored all mapping to use beans
 - Removed PATIENT_ID_CHECK code
@@ -210,55 +228,6 @@ The latest docker images are found on docker hub at https://hub.docker.com/repos
 - Upgraded to spring-boot-starter-parent 2.4.2
 - Resolves issues with path parsing 
 
-## Release 1.0.15-RELEASE 
-- Formal release
-
-## Release 1.0.14-SNAPSHOT
-- Added /find/all/questionnaireresponseitems
-- Added QueryKey: QuestionnaireResponse.QueryWithOptions
-
-## Release 1.0.13-SNAPSHOT
-- General QuestionnaireResponse Support
-- General type updates to transmit less empty data
-- GenericType supports coding and decimal
-- Added initial rest endpoints to clear caches
- - delete /cache
- - delete /cache/questionnaires
- - delete /cache/references
- - delete /cache/valuesets
- - delete /cache/querymappings
-- add endpoints to support QuestionnaireResponse retrieval
- - /find/latest/questionnaireresponse/?subject={subject}&code={code}
- - /find/latest/questionnaireresponseitem/?subject={subject}&code={code}
- - /summary/questionnaireresponses/?subject={subject}
- - /questionnaireresponse/{id}
- - /questionnaireresponse/?subject={subject}
-- added new fhir query keys
- - Questionnaire.Lookup=/Questionnaire/{id}
- - Questionnaire.FindForCode=/Questionnaire/?code={code}&_summary=true
- - QuestionnaireResponse.Query=/QuestionnaireResponse/?questionnaire={ids}&subject={subject}
- - QuestionnaireResponse.OpenQuery=/QuestionnaireResponse/?subject={subject}
- - QuestionnaireResponse.QueryLatest=/QuestionnaireResponse/?questionnaire={ids}&subject={subject}&status=completed,amended,in-progress&_sort=-authored&_count=1
- - QuestionnaireResponse.Summary.Query=/QuestionnaireResponse/?questionnaire={ids}&subject={subject}&_summary=true
- - QuestionnaireResponse.Summary.QueryLatest=/QuestionnaireResponse/?questionnaire={ids}&subject={subject}&_sort=-authored&_count=1&_summary=true
- - QuestionnaireResponse.Lookup=/QuestionnaireResponse/{id}
-
-
-## Release 1.0.12-SNAPSHOT
-- Updated Goals and Goal Summary for Acceptance
-- Added translate option "/find/latest/observation", so that recognized codes can translate to more complex queries, e.g. a Value set or containing parent observation.
-- Updated query parameter handling to have the first found instance take precedence.
-- fix value set loading to only load a value set once in the event the load list had duplicates
-- started support on procedures.
-
-## Release 1.0.11-SNAPSHOT
-- Updated /find/latest/observation to return empty observation when not found, status = "notfound"
-- Add hasImage to contact
-- Renamed util.Helper to FHIRHelper, added MccHelper
-- Added Age to Patient
-- Added Performer to Education and Counselling
-- Added Reason to Education and Counselling
-- Refactored and extended internal helpers.
 
 
 The full change log may be found and https://github.com/MccCareplan/mcc-api/blob/master/CHANGELOG.MD

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>com.cognitive.nih.niddk</groupId>
 	<artifactId>mcc-api</artifactId>
-	<version>1.0.17-RELEASE</version>
+	<version>1.0.18-RELEASE</version>
 	<name>mcc-api</name>
 	<description>MCC API Server</description>
 

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/controllers/ContactController.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/controllers/ContactController.java
@@ -29,8 +29,8 @@ public class ContactController {
     private final IR4Mapper mapper;
 
     @Value("${mcc.careteam.use.active}")
-    private String useActiveCareplans;
-    boolean isUseActiveCareplans;
+    private String useActiveCareTeams;
+    boolean isUseActiveCareTeams;
 
     @Value("${mcc.careteam.use.careplan}")
     private String useCareTeamsFromPlan;
@@ -44,7 +44,7 @@ public class ContactController {
     @PostConstruct
     public void Init()
     {
-        isUseActiveCareplans = Boolean.parseBoolean(useActiveCareplans);
+        isUseActiveCareTeams = Boolean.parseBoolean(useActiveCareTeams);
         isUseCareTeamsFromPlan = Boolean.parseBoolean(useCareTeamsFromPlan);
     }
 
@@ -131,9 +131,9 @@ public class ContactController {
             }
         }
 
-        if (!foundCareTeam && isUseActiveCareplans)
+        if (!foundCareTeam && isUseActiveCareTeams)
         {
-            //For some reason there was no careplan or associated caretem - So we will look for anyu active careteam
+            //For some reason there was no careplan or associated careteam - So we will look for any active careteam
             Map<String, String> values = new HashMap<>();
             values.put("subject", subjectId);
 

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/MccCodeableConcept.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/MccCodeableConcept.java
@@ -1,8 +1,10 @@
 package com.cognitive.nih.niddk.mccapi.data.primative;
 
 import com.cognitive.nih.niddk.mccapi.data.MccType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.validation.constraints.NotBlank;
 
@@ -13,5 +15,48 @@ public @Data class MccCodeableConcept implements MccType {
     @NotBlank
     private String text;
 
+    @JsonIgnore
+    public String getKey(String defSystem)
+    {
+        MccCoding fndCode=null;
+        if (!StringUtils.isEmpty(defSystem))
+        {
+            //Search the codings
+            for (MccCoding cd: coding)
+            {
+                if (cd.getSystem().compareTo(defSystem)==0)
+                {
+                    fndCode = cd;
+                    break;
+                }
+            }
+        }
+        if (fndCode == null)
+        {
+            //Default to first code
+            fndCode=coding[0];
+        }
+        return fndCode.getKey(defSystem);
 
+    }
+
+    @JsonIgnore
+    public MccCoding getCode(String system)
+    {
+        MccCoding fndCode=null;
+        if (!StringUtils.isEmpty(system))
+        {
+            //Search the codings
+            for (MccCoding cd: coding)
+            {
+                if (cd.getSystem().compareTo(system)==0)
+                {
+                    fndCode = cd;
+                    break;
+                }
+            }
+        }
+        return fndCode;
+
+    }
 }

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/MccCodeableConcept.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/MccCodeableConcept.java
@@ -18,6 +18,7 @@ public @Data class MccCodeableConcept implements MccType {
     @JsonIgnore
     public String getKey(String defSystem)
     {
+        String out = "Unknown";
         MccCoding fndCode=null;
         if (!StringUtils.isEmpty(defSystem))
         {
@@ -35,9 +36,13 @@ public @Data class MccCodeableConcept implements MccType {
         {
             //Default to first code
             fndCode=coding[0];
-        }
-        return fndCode.getKey(defSystem);
 
+        }
+
+        if (fndCode != null) {
+            out = fndCode.getKey(defSystem);
+        }
+        return out;
     }
 
     @JsonIgnore

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/MccCoding.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/MccCoding.java
@@ -1,8 +1,10 @@
 package com.cognitive.nih.niddk.mccapi.data.primative;
 
 import com.cognitive.nih.niddk.mccapi.data.MccType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.validation.constraints.NotBlank;
 
@@ -15,4 +17,23 @@ class MccCoding implements MccType {
     @NotBlank
     private String code;
     private String display;
+
+    @JsonIgnore public String getKey(String defSystem)
+    {
+        StringBuilder key = new StringBuilder();
+        if (!StringUtils.isEmpty(system))
+        {
+            key.append(system);
+        }
+        else
+        {
+            key.append(defSystem);
+        }
+        if (!StringUtils.isEmpty(code))
+        {
+            key.append("|");
+            key.append(code);
+        }
+       return key.toString();
+    }
 }

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/ObservationCollection.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/ObservationCollection.java
@@ -1,0 +1,50 @@
+package com.cognitive.nih.niddk.mccapi.data.primative;
+
+import com.cognitive.nih.niddk.mccapi.data.MccObservation;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Comparator;
+import java.util.HashMap;
+
+
+public class ObservationCollection {
+
+    @JsonIgnore
+    private HashMap<String, ObservationList> observationMap = new HashMap<>();
+
+    public void add(MccObservation obs, String defSystem)
+    {
+        String key = obs.getCode().getKey(defSystem);
+        ObservationList fndList;
+        if (!observationMap.containsKey(key))
+        {
+            fndList = new ObservationList();
+            observationMap.put(key,fndList);
+
+            MccCoding cd = obs.getCode().getCode(defSystem);
+            fndList.setPrimaryCode(cd);
+        }
+        else
+        {
+            fndList = observationMap.get(key);
+        }
+        fndList.add(obs);
+    }
+
+    public ObservationList[] getObservations() {
+        return observationMap.values().toArray(new ObservationList[0]);
+    }
+
+    public void sort(Comparator<MccObservation> comparator)
+    {
+        for (ObservationList list: observationMap.values())
+        {
+            list.sort(comparator);
+        }
+    }
+}
+

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/ObservationList.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/data/primative/ObservationList.java
@@ -1,0 +1,28 @@
+package com.cognitive.nih.niddk.mccapi.data.primative;
+
+import com.cognitive.nih.niddk.mccapi.data.MccObservation;
+import lombok.Data;
+import org.hl7.fhir.r4.model.CodeableConcept;
+
+import java.util.Comparator;
+import java.util.LinkedList;
+
+@Data
+public class ObservationList {
+    private MccCoding primaryCode;
+
+    private LinkedList<MccObservation> observations = new LinkedList<>();
+
+
+    public void add(MccObservation obs)
+    {
+        observations.add(obs);
+    }
+
+    public void sort(Comparator<MccObservation> comparator) {
+        if (observations.size()>1)
+        {
+           observations.sort(comparator);
+        }
+    }
+}

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/CareTeamMapper.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/CareTeamMapper.java
@@ -21,7 +21,7 @@ public class CareTeamMapper implements ICareTeamMapper {
     public  List<Contact> fhir2Contacts(CareTeam in, Context ctx) {
         ArrayList<Contact> out = new ArrayList<>();
         String teamName = in.getName();
-        String teamId = in.getIdElement().getResourceType() + "/" + in.getIdElement().getId();
+        String teamId = in.getIdElement().getResourceType() + "/" + in.getIdElement().getIdPart().toString();
         Date now = new Date();
         if (in.hasPeriod())
         {
@@ -108,26 +108,46 @@ public class CareTeamMapper implements ICareTeamMapper {
             else
             {
                 String type = FHIRHelper.getReferenceType(m);
-                if (type.compareTo("Practitioner") == 0)
+                switch (type)
                 {
-                    Practitioner p = ReferenceResolver.findPractitioner(m,ctx);
-                    if (p != null) {
-                        out = mapper.fhir2Contact(p, ctx);
-                    }
-                }
-                else if (type.compareTo("RelatedPerson")==0)
-                {
-                    RelatedPerson r = ReferenceResolver.findRelatedPerson(m,ctx);
-                    if ( r != null) {
-                        out = mapper.fhir2Contact(r,ctx);
-                    }
-                }
-                else if (type.compareTo("Organization")==0)
-                {
-                    Organization o = ReferenceResolver.findOrganization(m, ctx);
-                    if (o != null)
+                    case "Practitioner":
                     {
-                        out = mapper.fhir2Contact(o,ctx);
+                        Practitioner p = ReferenceResolver.findPractitioner(m,ctx);
+                        if (p != null) {
+                            out = mapper.fhir2Contact(p, ctx);
+                        }
+                        break;
+                    }
+                    case "RelatedPerson":
+                    {
+                        RelatedPerson r = ReferenceResolver.findRelatedPerson(m,ctx);
+                        if ( r != null) {
+                            out = mapper.fhir2Contact(r,ctx);
+                        }
+                        break;
+                    }
+                    case "Organization":
+                    {
+                        Organization o = ReferenceResolver.findOrganization(m, ctx);
+                        if (o != null)
+                        {
+                            out = mapper.fhir2Contact(o,ctx);
+                        }
+                        break;
+                    }
+                    case "Patient":
+                    {
+                        //In contacts already included
+                        break;
+                    }
+                    case "PractitionerRole":
+                    {
+                        break;
+                    }
+                    default:
+                    {
+                        log.warn("Unknown careteam member type ("+type+") not handled");
+                        break;
                     }
                 }
 

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/IPractitionerRoleMapper.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/IPractitionerRoleMapper.java
@@ -1,0 +1,11 @@
+package com.cognitive.nih.niddk.mccapi.mappers;
+
+import com.cognitive.nih.niddk.mccapi.data.Contact;
+import com.cognitive.nih.niddk.mccapi.data.Context;
+import org.hl7.fhir.r4.model.Practitioner;
+import org.hl7.fhir.r4.model.PractitionerRole;
+
+public interface IPractitionerRoleMapper {
+    Contact fhir2Contact(PractitionerRole in, Context ctx);
+    void updateContact(PractitionerRole in, Contact contact, Context ctx);
+}

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/IR4Mapper.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/IR4Mapper.java
@@ -53,6 +53,8 @@ public interface IR4Mapper {
     Referral fhir2local(ServiceRequest in, Context ctx);
     ReferralSummary fhir2summary(ServiceRequest in, Context ctx);
     Contact fhir2Contact(RelatedPerson in, Context ctx);
+    Contact fhir2Contact(PractitionerRole in, Context ctx);
+    void updateContact(PractitionerRole in, Contact contact, Context ctx);
 
     // Types
     GenericType fhir2local(Type in, Context ctx);

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/PractitionerRoleMapper.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/PractitionerRoleMapper.java
@@ -1,0 +1,54 @@
+package com.cognitive.nih.niddk.mccapi.mappers;
+
+import com.cognitive.nih.niddk.mccapi.data.Contact;
+import com.cognitive.nih.niddk.mccapi.data.Context;
+import com.cognitive.nih.niddk.mccapi.util.FHIRHelper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.hl7.fhir.r4.model.ContactPoint;
+import org.hl7.fhir.r4.model.PractitionerRole;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class PractitionerRoleMapper implements IPractitionerRoleMapper {
+    @Override
+    public Contact fhir2Contact(PractitionerRole in, Context ctx) {
+        Contact out = new Contact();
+        //Deal with contact points
+        List<ContactPoint> contactPoints = FHIRHelper.filterToCurrentContactPoints(in.getTelecom());
+        Map<String, List<ContactPoint>> cpBySystem = FHIRHelper.organizeContactTypesBySystem(contactPoints);
+        ContactPoint bestPhone = FHIRHelper.findBestContactByType(cpBySystem, "phone", "work|mobile|home");
+        if (bestPhone != null) {
+            out.setPhone(bestPhone.getValue());
+        }
+        ContactPoint bestEmail = FHIRHelper.findBestContactByType(cpBySystem, "email", "work|mobile");
+        if (bestEmail != null) {
+            out.setEmail(bestEmail.getValue());
+        }
+        return out;
+    }
+
+    @Override
+    public void updateContact(PractitionerRole in, Contact out, Context ctx) {
+        //Deal with contact points
+        List<ContactPoint> contactPoints = FHIRHelper.filterToCurrentContactPoints(in.getTelecom());
+        Map<String, List<ContactPoint>> cpBySystem = FHIRHelper.organizeContactTypesBySystem(contactPoints);
+        if (StringUtils.isBlank(out.getPhone())) {
+            ContactPoint bestPhone = FHIRHelper.findBestContactByType(cpBySystem, "phone", "work|mobile|home");
+            if (bestPhone != null) {
+                out.setPhone(bestPhone.getValue());
+            }
+        }
+        if (StringUtils.isBlank((out.getEmail()))) {
+            ContactPoint bestEmail = FHIRHelper.findBestContactByType(cpBySystem, "email", "work|mobile");
+            if (bestEmail != null) {
+                out.setEmail(bestEmail.getValue());
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/R4Mapper.java
+++ b/src/main/java/com/cognitive/nih/niddk/mccapi/mappers/R4Mapper.java
@@ -24,13 +24,14 @@ public class R4Mapper implements IR4Mapper {
     private final IOrganizationMapper organizationMapper;
     private final IPatientMapper patientMapper;
     private final IPractitionerMapper practitionerMapper;
+    private final IPractitionerRoleMapper practitionerRoleMapper;
     private final IProcedureMapper procedureMapper;
     private final IQuestionnaireResponseMapper questionnaireResponseMapper;
     private final IReferenceMapper referenceMapper;
     private final IReferralMapper referralMapper;
     private final IRelatedPersonMapper relatedPersonMapper;
 
-    public R4Mapper(ICareplanMapper careplanMapper, ICareTeamMapper careTeamMapper, ICodeableConceptMapper codeableConceptMapper, IConditionMapper conditionMapper, ICounselingMapper counselingMapper, IEducationMapper educationMapper, IGenericTypeMapper genericTypeMapper, IGoalMapper goalMapper, IMedicationMapper medicationMapper, IObservationMapper observationMapper, IOrganizationMapper organizationMapper, IPatientMapper patientMapper, IPractitionerMapper practitionerMapper, IProcedureMapper procedureMapper, IQuestionnaireResponseMapper questionnaireResponseMapper, IReferenceMapper referenceMapper, IReferralMapper referralMapper, IRelatedPersonMapper relatedPersonMapper) {
+    public R4Mapper(ICareplanMapper careplanMapper, ICareTeamMapper careTeamMapper, ICodeableConceptMapper codeableConceptMapper, IConditionMapper conditionMapper, ICounselingMapper counselingMapper, IEducationMapper educationMapper, IGenericTypeMapper genericTypeMapper, IGoalMapper goalMapper, IMedicationMapper medicationMapper, IObservationMapper observationMapper, IOrganizationMapper organizationMapper, IPatientMapper patientMapper, IPractitionerMapper practitionerMapper, IPractitionerRoleMapper practitionerRoleMapper, IProcedureMapper procedureMapper, IQuestionnaireResponseMapper questionnaireResponseMapper, IReferenceMapper referenceMapper, IReferralMapper referralMapper, IRelatedPersonMapper relatedPersonMapper) {
         this.careplanMapper = careplanMapper;
         this.careTeamMapper = careTeamMapper;
         this.codeableConceptMapper = codeableConceptMapper;
@@ -44,6 +45,7 @@ public class R4Mapper implements IR4Mapper {
         this.organizationMapper = organizationMapper;
         this.patientMapper = patientMapper;
         this.practitionerMapper = practitionerMapper;
+        this.practitionerRoleMapper = practitionerRoleMapper;
         this.procedureMapper = procedureMapper;
         this.questionnaireResponseMapper = questionnaireResponseMapper;
         this.referenceMapper = referenceMapper;
@@ -350,6 +352,16 @@ public class R4Mapper implements IR4Mapper {
     @Override
     public Contact fhir2Contact(RelatedPerson in, Context ctx) {
         return relatedPersonMapper.fhir2Contact(in,ctx);
+    }
+
+    @Override
+    public Contact fhir2Contact(PractitionerRole in, Context ctx) {
+        return practitionerRoleMapper.fhir2Contact(in,ctx);
+    }
+
+    @Override
+    public void updateContact(PractitionerRole in, Contact contact, Context ctx) {
+        practitionerRoleMapper.updateContact(in,contact,ctx);
     }
 
     @Override

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -10,3 +10,6 @@ hapi.logging.response.summary=true
 hapi.logging.response.body=false
 hapi.logging.response.header=false
 mcc.patient.id.system=
+mcc.provider.pullbyrole=true
+mcc.careteam.use.active=true
+mcc.careteam.use.careplan=true

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -3,3 +3,6 @@ springdoc.api-docs.path=/api-docs
 fhir.default.server.address=https://api.logicahealth.org/MCCeCarePlanTest/open
 fhir.secure.server.address=https://api.logicahealth.org/MCCeCarePlanTest/data
 mcc.patient.id.system=
+mcc.provider.pullbyrole=true
+mcc.careteam.use.active=true
+mcc.careteam.use.careplan=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,6 @@
 spring.profiles.active=@spring.profiles.active@
 springdoc.api-docs.path=/api-docs
 hapi.logging.enables=true
-
+mcc.provider.pullbyrole=true
+mcc.careteam.use.active=true
+mcc.careteam.use.careplan=true

--- a/src/main/resources/fhirqueries.properties
+++ b/src/main/resources/fhirqueries.properties
@@ -4,6 +4,9 @@
 CarePlan.Query=/CarePlan/?subject={subject}
 CarePlan.Lookup=/CarePlan/{id}
 
+#CareTeam related
+CareTeam.Query.ActiveList=/CareTeam/?subject={subject}&status=active
+
 #Conditions
 Condition.Lookup=/Condition/{id}
 Condition.QueryProblemList=/Condition/?subject={subject}&category=http%3A%2F%2Fterminology.hl7.org%2FCodeSystem%2Fcondition-category%7Cproblem-list-item
@@ -43,7 +46,7 @@ Goal.Lookup=/Goal/{id}
 Practitioner.Lookup=/Practitioner/{id}
 
 #PractitionerRole
-PractitionerRole.Query=/PractitionerRole/?practitioner={reference}
+PractitionerRole.Query=/PractitionerRole/?practitioner={id}&active=true
 
 #MedicationRequest
 MedicationRequest.Query=/MedicationRequest/?subject={subject}


### PR DESCRIPTION
Fixes for supporting the CareTeam data fetch at OHSU and support for the new query /observationssegmented/?subject={id}&valueset={ValueSet} which will return each different code in a value set with a related date ordered collection of that code so that we can graph eGFR into different lines. I have added two new data points to the test data set to support this too.

Example: {{APIServer}}/observationssegmented/?subject=cc-pat-pnoelle&valueset=2.16.840.1.113762.1.4.1222.179. 